### PR TITLE
Fixed armorstand placement glitch

### DIFF
--- a/src/com/gmail/St3venAU/plugins/ArmorStandTools/MainListener.java
+++ b/src/com/gmail/St3venAU/plugins/ArmorStandTools/MainListener.java
@@ -187,8 +187,12 @@ public class MainListener implements Listener {
                 Utils.actionBarMsg(p, Config.asDropped);
                 return;
             }
-            as.teleport(Utils.getLocationFacingPlayer(p));
-            Utils.actionBarMsg(p, ChatColor.GREEN + Config.carrying);
+            Location loc = Utils.getLocationFacingPlayer(p);
+            Location previous = as.getLocation();
+            if ((previous.getBlockX() == loc.getBlockX() && previous.getBlockZ() == loc.getBlockZ()) || plugin.checkBlockPermission(p, loc.getBlock())) {
+                as.teleport(loc);
+                Utils.actionBarMsg(p, ChatColor.GREEN + Config.carrying);
+            }
         }
     }
 


### PR DESCRIPTION
To recreate
1. Make an armor stand on your plot.
2. Go to a plot you want to put it on
3. Change your gamemode to gamemode 3
4. Teleport to someone using the gamemode 3 feature. DO NOT MOVE THE MOUSE
5. The armor stand should still be there, and not teleported to you
6. Disconnect from the server, and reconnect.
7. Go to the place where you wanted to place it in gamemode 3
8. The armor stand is should still be there.