### PR TITLE
Fix ChestShop Exploit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,10 @@
         <id>IntellectualSites</id>
         <url>https://mvn.intellectualsites.com/content/groups/public/</url>
     </repository>
+    <repository>
+        <id>chestshop-repo</id>
+        <url>https://repo.minebench.de/</url>
+    </repository>
 </repositories>
 
 <dependencies>
@@ -49,6 +53,12 @@
         <groupId>com.plotsquared</groupId>
         <artifactId>PlotSquared-Core</artifactId>
         <version>5.13.3</version>
+    </dependency>
+    <dependency>
+        <groupId>com.acrobot.chestshop</groupId>
+        <artifactId>chestshop</artifactId>
+        <version>3.11</version>
+        <scope>provided</scope>
     </dependency>
 </dependencies>
 

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ChestShopHook.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ChestShopHook.java
@@ -1,0 +1,25 @@
+package com.gmail.St3venAU.plugins.ArmorStandTools;
+
+import com.Acrobot.ChestShop.Events.PreTransactionEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class ChestShopHook implements Listener {
+
+    private final Main plugin;
+
+    public ChestShopHook(Main plugin) {
+        this.plugin = plugin;
+        PreTransactionEvent.getHandlerList().unregister(plugin); // Avoid multiple registers
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
+    public void onPreTransactionEvent(PreTransactionEvent event) {
+        if (plugin.savedInventories.containsKey(event.getClient().getUniqueId())) {
+            event.setCancelled(true);
+        }
+    }
+
+}

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Config.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Config.java
@@ -195,6 +195,19 @@ class Config {
             plugin.getLogger().log(Level.WARNING, "WorldGuard plugin was found, but integrateWithWorldGuard is set to false in config.yml. Continuing without WorldGuard support.");
             worldGuardPlugin = null;
         }
+
+        Plugin chestShop = plugin.getServer().getPluginManager().getPlugin("ChestShop");
+        if (chestShop != null && chestShop.isEnabled()) {
+            try {
+                new ChestShopHook(plugin);
+                plugin.getLogger().log(Level.INFO, "ChestShop plugin was found. ChestShop support enabled.");
+            } catch (Throwable e) {
+                e.printStackTrace();
+                plugin.getLogger().log(Level.WARNING, "ChestShop plugin was found, but there was an error initializing ChestShop support.");
+            }
+        } else {
+            plugin.getLogger().log(Level.INFO, "ChestShop plugin not found. Continuing without ChestShop support.");
+        }
     }
 
     private static void reloadLanguageConfig() {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: ${project.version}
 api-version: 1.13
 author: St3venAU
 description: Armor stand manipulation tools
-softdepend: [WorldGuard, PlotSquared]
+softdepend: [WorldGuard, PlotSquared, Chestshop]
 commands:
    astools:
       description: Give yourself the armor stand tools


### PR DESCRIPTION
There exists an exploit where players are able to take items from the /ast inventory if the server uses the ChestShop plugin. This exploit is better described at https://www.spigotmc.org/threads/armor-stand-tools.38107/page-27#post-3889861. Aurelien30000 has already fixed the issues in his ChestShop fork (https://github.com/Aurelien30000/ArmorStandTools). and I've created this PR to help add the three ChestShop related commits from his fork to the official plugin.  

I've been using his fork for months now without any issues, so I believe these changes should work as expected.