### PR TITLE
Update and fix dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,20 @@
     <!-- WorldEdit / WorldGuard -->
     <repository>
         <id>sk89q-repo</id>
-        <url>http://maven.sk89q.com/repo/</url>
+        <url>https://maven.sk89q.com/repo/</url>
     </repository>
     <!-- PlotSquared -->
     <repository>
-        <id>IntellectualSites</id>
-        <url>https://mvn.intellectualsites.com/content/groups/public/</url>
+        <id>intellectualsites releases</id>
+        <url>https://mvn.intellectualsites.com/content/repositories/releases/</url>
+    </repository>
+    <repository>
+        <id>intellectualsites snapshots</id>
+        <url>https://mvn.intellectualsites.com/content/repositories/snapshots/</url>
+    </repository>
+    <repository> <!-- needed due to missing dependency on PlotSquared for adventure-text-minimessage -->
+        <id>sonatype-oss-snapshots</id>
+        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
 </repositories>
 
@@ -52,7 +60,7 @@
     <dependency>
         <groupId>com.plotsquared</groupId>
         <artifactId>PlotSquared-Core</artifactId>
-        <version>6.0.6-SNAPSHOT</version>
+        <version>6.1.3</version>
     </dependency>
 </dependencies>
 


### PR DESCRIPTION
PlotSquared-Core now depends on `adventure-text-minimessage` which is missing from its own dependencies for whatever reason. They also changed their repository URL.

This also fixes missing `https` on the `sk89q` repo.

I didn't see #54 before doing this. That pull request also looks good to me :)