### PR TITLE
Fix itemedit renaming dupe and depend repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <!-- WorldEdit / WorldGuard -->
     <repository>
         <id>sk89q-repo</id>
-        <url>https://maven.sk89q.com/repo/</url>
+        <url>https://maven.enginehub.org/repo/</url>
     </repository>
     <!-- PlotSquared -->
     <repository>
@@ -60,7 +60,7 @@
     <dependency>
         <groupId>com.plotsquared</groupId>
         <artifactId>PlotSquared-Core</artifactId>
-        <version>6.1.3</version>
+        <version>6.9.0</version>
     </dependency>
 </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>com.gmail.st3venau.plugins</groupId>
 <artifactId>ArmorStandTools</artifactId>
-<version>4.4.4</version>
+<version>4.4.5</version>
 <name>ArmorStandTools</name>
 
 <repositories>

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/AST.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/AST.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.WorldGuard;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/AST.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/AST.java
@@ -18,6 +18,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
@@ -25,6 +26,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.AbstractMap;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -162,6 +164,25 @@ public class AST extends JavaPlugin {
         PlayerInventory i = p.getInventory();
         for(ArmorStandTool t : ArmorStandTool.values()) {
             i.remove(t.getItem());
+
+            Collection<? extends ItemStack> materialItems = i.all(t.getItem().getType()).values();
+            ItemMeta toolMeta = t.getItem().getItemMeta();
+            if (toolMeta == null) {
+                continue;
+            }
+
+            String toolLocalizedName = toolMeta.getLocalizedName();
+            for (ItemStack invItem : materialItems) {
+                ItemMeta inventoryItemMeta = invItem.getItemMeta();
+
+                if (inventoryItemMeta == null) {
+                    continue;
+                }
+
+                if (toolLocalizedName.equals(inventoryItemMeta.getLocalizedName())) {
+                    i.remove(invItem);
+                }
+            }
         }
     }
 

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandCmd.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandCmd.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandCmdManager.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandCmdManager.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import org.bukkit.ChatColor;
 import org.bukkit.entity.ArmorStand;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandGUI.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandGUI.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandTool.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandTool.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Material;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandTool.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandTool.java
@@ -79,6 +79,7 @@ public enum ArmorStandTool {
         if(meta != null) {
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+            meta.setLocalizedName("ArmorStandTool");
             item.setItemMeta(meta);
         }
         this.config_id = config_id;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/CommandType.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/CommandType.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 enum CommandType {
 

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Commands.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Commands.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import org.jetbrains.annotations.NotNull;
 import org.bukkit.ChatColor;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Config.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Config.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import org.bukkit.Material;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/MainListener.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/MainListener.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/PlotSquaredHook.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/PlotSquaredHook.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import com.plotsquared.core.PlotAPI;
 import com.plotsquared.core.player.PlotPlayer;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Utils.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Utils.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
-main: com.gmail.st3venau.plugins.armorstandtools.AST
+main: com.gmail.St3venAU.plugins.ArmorStandTools.AST
 name: ArmorStandTools
 version: ${project.version}
 api-version: 1.17


### PR DESCRIPTION
ItemEdit dupe. When using /ast and renaming, or changing another meta of items (e.g nether star), for example, via ItemEdit plugin, this item will not removed when use /ast again. Fixed by adding unused localized name meta for item and checking by it.
Changed package names because path and package name is not same. Intellij idea shows errors, so I fixed it.
sk89q's repo is already unavalible, so i changed it to enginehub repo