### PR TITLE
Fix item NBT data getting erased when 'Pick Up as Item' is used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <!-- WorldEdit / WorldGuard -->
     <repository>
         <id>sk89q-repo</id>
-        <url>https://maven.sk89q.com/repo/</url>
+        <url>https://maven.enginehub.org/repo/</url>
     </repository>
     <!-- PlotSquared -->
     <repository>
@@ -60,7 +60,7 @@
     <dependency>
         <groupId>com.plotsquared</groupId>
         <artifactId>PlotSquared-Core</artifactId>
-        <version>6.1.3</version>
+        <version>6.9.0</version>
     </dependency>
 </dependencies>
 

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/AST.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/AST.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.WorldGuard;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandCmd.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandCmd.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandCmdManager.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandCmdManager.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import org.bukkit.ChatColor;
 import org.bukkit.entity.ArmorStand;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandGUI.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandGUI.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandTool.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ArmorStandTool.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Material;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/CommandType.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/CommandType.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 enum CommandType {
 

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Commands.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Commands.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import org.jetbrains.annotations.NotNull;
 import org.bukkit.ChatColor;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Config.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Config.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import org.bukkit.Material;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ItemStackNBT.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ItemStackNBT.java
@@ -6,6 +6,7 @@ import org.bukkit.inventory.ItemStack;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+// CREDIT: This class is based on the MiniNBT library: https://github.com/I-Al-Istannen/MiniNBT
 public class ItemStackNBT {
     private final static Method AS_NMS_COPY;
     private final static Method GET_TAG;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ItemStackNBT.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/ItemStackNBT.java
@@ -1,0 +1,67 @@
+package com.gmail.St3venAU.plugins.ArmorStandTools;
+
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.ItemStack;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class ItemStackNBT {
+    private final static Method AS_NMS_COPY;
+    private final static Method GET_TAG;
+    private final static Method TAG_TO_STRING;
+    private static final String SERVER_VERSION;
+
+    static {
+        boolean runningUnderTest = Bukkit.getServer() == null
+                || Bukkit.getServer().getClass().getName().contains("Mockito");
+
+        String name = runningUnderTest
+                ? "org.bukkit.craftbukkit.v1_14_R1"
+                : Bukkit.getServer().getClass().getPackage().getName();
+        String[] split = name.split("\\.");
+        name = split[split.length - 1];
+
+        SERVER_VERSION = name;
+        Class<?> craftItemStackClass;
+        Class<?> itemStackClass;
+        Class<?> compoundTagClass;
+        try {
+            craftItemStackClass = Class.forName("org.bukkit.craftbukkit." + SERVER_VERSION + ".inventory.CraftItemStack");
+            itemStackClass = Class.forName("net.minecraft.world.item.ItemStack");
+            compoundTagClass = Class.forName("net.minecraft.nbt.NBTTagCompound");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+        try {
+            AS_NMS_COPY = craftItemStackClass.getMethod("asNMSCopy", ItemStack.class);
+            GET_TAG = itemStackClass.getDeclaredMethod("getTagClone");
+            GET_TAG.setAccessible(true);
+            TAG_TO_STRING = compoundTagClass.getMethod("toString");
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String itemToString(ItemStack item){
+        Object nmsItem;
+        try {
+            nmsItem = AS_NMS_COPY.invoke(null, item);
+
+            if (nmsItem == null) {
+                throw new NullPointerException("Unable to find a nms item clone for " + item);
+            }
+
+            Object tag = GET_TAG.invoke(nmsItem);
+
+            if (tag == null) {
+                return null;
+            }
+
+            return (String) TAG_TO_STRING.invoke(tag);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    //
+}

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/MainListener.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/MainListener.java
@@ -1,11 +1,10 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameRule;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.ArmorStand;
@@ -37,14 +36,12 @@ import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 @SuppressWarnings("CommentedOutCode")
 public class MainListener implements Listener {

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/PlotSquaredHook.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/PlotSquaredHook.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import com.plotsquared.core.PlotAPI;
 import com.plotsquared.core.player.PlotPlayer;

--- a/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Utils.java
+++ b/src/main/java/com/gmail/St3venAU/plugins/ArmorStandTools/Utils.java
@@ -1,4 +1,4 @@
-package com.gmail.st3venau.plugins.armorstandtools;
+package com.gmail.St3venAU.plugins.ArmorStandTools;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -137,46 +137,6 @@ class Utils {
         return false;
     }
 
-    static private String getItemStackTags(ItemStack is) {
-        if(is == null) {
-            return "";
-        }
-        StringBuilder tags = new StringBuilder();
-        if(is.getItemMeta() != null && is.getItemMeta() instanceof LeatherArmorMeta armorMeta) {
-            tags.append("display:{color:");
-            tags.append(armorMeta.getColor().asRGB());
-            tags.append("}");
-        }
-        Map<Enchantment, Integer> enchants = is.getEnchantments();
-        if(enchants.size() > 0) {
-            if(tags.length() > 0) {
-                tags.append(",");
-            }
-            tags.append("Enchantments:[");
-
-            for(Enchantment e : enchants.keySet()) {
-                tags.append("{id:");
-                tags.append(e.getKey().getKey());
-                tags.append(",lvl:");
-                tags.append(enchants.get(e));
-                tags.append("},");
-            }
-
-            tags.setCharAt(tags.length() - 1, ']');
-        }
-        return tags.length() == 0 ? "" : tags.toString();
-    }
-    
-    static private int getItemCustomModelData(ItemStack is) {
-        if(is == null || is.getItemMeta() == null || !is.getItemMeta().hasCustomModelData()) return 0;
-        return is.getItemMeta().getCustomModelData();
-    }
-
-    static private String skullOwner(ItemStack is) {
-        if(is == null || is.getItemMeta() == null || !(is.getItemMeta() instanceof SkullMeta skull)) return "";
-        return skull.getOwningPlayer() == null ? "" : "SkullOwner:\"" + skull.getOwner() + "\"";
-    }
-
     static private boolean isEmpty(ItemStack is) {
         return is == null || is.getType() == Material.AIR;
     }
@@ -188,33 +148,10 @@ class Utils {
         if(is.getAmount() > 0) {
             sb.append(",Count:").append(is.getAmount());
         }
-        String itemStackTags = getItemStackTags(is);
-        @SuppressWarnings("deprecation")
-        short durability = is.getDurability();
-        String skullOwner = skullOwner(is);
-        int customModelData = getItemCustomModelData(is);
-        int n = 0;
-        if(itemStackTags.length() > 0 || durability > 0 || skullOwner.length() > 0) {
-            sb.append(",tag:{");
-            if(durability > 0) {
-                sb.append("Damage:").append(durability);
-                n++;
-            }
-            if(customModelData > 0) {
-                if(n > 0) sb.append(",");
-                sb.append("CustomModelData:").append(customModelData);
-                n++;
-            }
-            if(itemStackTags.length() > 0) {
-                if(n > 0) sb.append(",");
-                sb.append(itemStackTags);
-                n++;
-            }
-            if(skullOwner.length() > 0) {
-                if(n > 0) sb.append(",");
-                sb.append(skullOwner);
-            }
-            sb.append("}");
+        String itemStackTags = ItemStackNBT.itemToString(is);
+        if(itemStackTags != null && !itemStackTags.isEmpty()) {
+            sb.append(",tag:");
+            sb.append(itemStackTags);
         }
         sb.append("}");
         return sb.toString();
@@ -455,7 +392,4 @@ class Utils {
         clone.setMetadata("clone", new FixedMetadataValue(AST.plugin, true));
         return clone;
     }
-
-
-
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
-main: com.gmail.st3venau.plugins.armorstandtools.AST
+main: com.gmail.St3venAU.plugins.ArmorStandTools.AST
 name: ArmorStandTools
 version: ${project.version}
 api-version: 1.17


### PR DESCRIPTION
Using the tool 'Pick Up as Item' causes all items that are equipped on the armor stand to lose all NBT data apart from enchantments and durability.

I fixed it using a bit of reflection to retrieve the NBT directly from the ItemStack and then convering it to string using .toString(). Since all the string generating is handled by the server, the code could be simplified a bit by removing some not used functions.

Tested on 1.19.2, 1.18.2 and 1.17.1

